### PR TITLE
After require, delete this module from the cache

### DIFF
--- a/lib/mockit.js
+++ b/lib/mockit.js
@@ -23,3 +23,5 @@ module.exports = function (path, mocks) {
   // Return the module
   return file;
 };
+
+delete require.cache[__filename];


### PR DESCRIPTION
Because of caching, mockit's `module.parent` always refers to the first file from which it is called.   That kinda works out if all of your test files are in the same directory, since the path used to resolve things will be the same.   I like to keep my tests in the same directory as the file they're testing and that means that the require paths don't match up.  

```
/lib
   /model
       /user.js
       /user.test.js
   /controller
       /login.js
       /login.test.js
```

In the example directory structure above, if both `user.test.js` and `login.test.js` use mockit, when the user test calls `require('./user')` it'll work just fine because it runs first, but then when the login test calls `require('./login')` an error will be thrown because it's actually looking for the file at `/lib/model/login.js` due to `module.parent` still referring to `user.test.js`.

Deleting mockit from `require.cache` means `module.parent` actually refers the file that just required it.
